### PR TITLE
Basic Pawn/Capture With Websocket Integration

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -8,7 +8,7 @@ async def main(websocket):
     board = ChessBoard()
     board.create_starting_board()    
 
-    await websocket.send(board.board_to_json())
+    await websocket.send(board.game_to_json())
 
     # Runs everytime client sends data
     async for move in websocket:
@@ -18,9 +18,10 @@ async def main(websocket):
         endMove = moves[2]
 
         # Do move and update board
-        board.move_piece(startMove, endMove)
-
-        # Send resulting board state
-        await websocket.send(board.board_to_json())
+        if(board.can_move_piece(startMove, endMove)):
+            board.move_piece(startMove, endMove)
+            
+            # Send resulting board/game state
+            await websocket.send(board.game_to_json())            
 
 asyncio.run(server(main))

--- a/engine/board.py
+++ b/engine/board.py
@@ -1,10 +1,12 @@
-# Acts as the board for the game
+# Acts as the board/game 
 from pieces import Pawn
 import json
 
 class ChessBoard:
 	def __init__(self):
 		self.board = self.create_starting_board()
+		self.captured_whites = []
+		self.captured_blacks = []
 
 	def create_starting_board(self):
 		# Make basic 8x8 board
@@ -21,19 +23,52 @@ class ChessBoard:
 		for row in self.board:
 			print(' '.join(['.' if square is None else str(square) for square in row]))
 
-	# convert 2d array of board to json string
-	def board_to_json(self):
+	# convert 2d array of board state and info to json
+	def game_to_json(self):
 		board_arr = []
 		for row in self.board:
 			row_arr = ['.' if square is None else str(square) for square in row]
 			board_arr.append(row_arr)
-		return json.dumps(board_arr)
 
-	# naive approach for moving a piece without validation
-	def move_piece(self, start_pos, end_pos):
+		captured_white = [str(piece) for piece in self.captured_whites]
+		captured_black = [str(piece) for piece in self.captured_blacks]
+
+		# Create a dictionary to hold all game data
+		game_state = {
+			'board': board_arr,
+			'captured_white': captured_white,
+			'captured_black': captured_black
+		}
+
+		return json.dumps(game_state)
+	
+	# Checks if a piece can legally be moved to the square the user has requested
+	def can_move_piece(self, start_pos, end_pos):
+		# Convert chess moves to coordinates
 		start_row, start_col = self.convert_to_index(start_pos)
 		end_row, end_col = self.convert_to_index(end_pos)
-		#print(f'start row: {start_row}, start col: {start_col}, end row: {end_row}, end col: {end_col}')
+		# Validate the move
+		if (self.board[start_row][start_col] != None): # If space to validate isnt None
+			if (self.board[start_row][start_col].validate_Move(start_row, start_col, end_row, end_col, self.board)):
+				return True
+		return False
+
+	# Moves a piece and sees if it has captured anything in the process
+	def move_piece(self, start_pos, end_pos):
+		# Convert chess moves to coordinates
+		start_row, start_col = self.convert_to_index(start_pos)
+		end_row, end_col = self.convert_to_index(end_pos)
+
+		# See if there was a piece there
+		if self.board[end_row][end_col] is not None:
+			captured_piece = self.board[end_row][end_col]
+			captured_piece.capture()
+
+			if captured_piece.color == 'white':
+				self.captured_whites.append(captured_piece)
+			else:
+				self.captured_blacks.append(captured_piece)
+
 		self.board[end_row][end_col] = self.board[start_row][start_col]
 		self.board[start_row][start_col] = None
 

--- a/engine/pieces.py
+++ b/engine/pieces.py
@@ -13,6 +13,9 @@ class Piece:
 	def capture(self):
 		self.is_captured = True
 
+	def validate_Move(end_row, end_col):
+		return True
+
 	def __str__(self):
 		return self.type[0]
 
@@ -20,5 +23,26 @@ class Pawn(Piece):
 	def __init__(self, color, position):
 		super().__init__(color, 'Pawn', position)
 
+	def validate_Move(self, start_row, start_col, end_row, end_col, board):
+		# Check if white pawn just moving up one square (doesn't check if moves out of range)
+		if self.color == 'white' and end_row == start_row - 1 and board[end_row][end_col] == None and end_col == start_col:
+			return True
+		elif self.color == 'black' and end_row == start_row + 1 and board[end_row][end_col] == None and end_col == start_col:
+			return True
+
+		# Check if they doing a double move
+		if self.color == 'white' and end_row == start_row - 2 and board[end_row][end_col] == None and end_col == start_col and start_row == 6:
+			return True
+		elif self.color == 'black' and end_row == start_row + 2 and board[end_row][end_col] == None and end_col == start_col and start_row == 1:
+			return True
+		
+		# Check for capture
+		if self.color == 'white' and end_row == start_row - 1 and board[end_row][end_col] and ((end_col == start_col + 1 and start_col + 1 < 8) or (end_col == start_col - 1 and start_col - 1 > -1)):
+			# Set the other object 
+			return True
+		elif self.color == 'black' and end_row == start_row + 1 and board[end_row][end_col] and ((end_col == start_col + 1 and start_col + 1 < 8) or (end_col == start_col - 1 and start_col - 1 > -1)):
+			return True
+		
+		return False
 	def __str__(self):
 		return 'p'

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,14 +4,21 @@ import { useWebSocket } from '@vueuse/core'
 
 const { status, data, send, open, close } = useWebSocket('ws://localhost:9090')
 
-// Make structure to send move
+// Different chess data
 const startMove = ref('');
 const endMove = ref('');
-const chessboard = ref([])
+const chessboard = ref([]);
+const capturedWhite = ref([]);
+const capturedBlack = ref([]);
+
 
 watch(data, (newData) => {
-  // When data changes, update chessboard
-  chessboard.value = JSON.parse(newData)
+  // When data changes, update game info
+  const parsedData = JSON.parse(newData)
+
+  chessboard.value = parsedData.board;
+  capturedWhite.value = parsedData.captured_white;
+  capturedBlack.value = parsedData.captured_black;
 })
 
 // method that constructs the move string 
@@ -27,14 +34,18 @@ const sendMove = () => {
 <template>
   <h1>Example Chess App</h1>
   <p>Status: {{ status }}</p>
+
+  <!-- Chessboard Representation -->
   <table class="chessboard">
     <tr v-for="(row, rowIndex) in chessboard" :key="rowIndex">
+      <!-- Show the row numbers -->
       <th>{{ 8 - rowIndex }}</th>
       <td v-for="(cell, cellIndex) in row" :key="cellIndex">
         {{ cell }}
       </td>
     </tr>
     <tr>
+      <!-- Show the column letters -->
       <th></th> 
       <th v-for="colLabel in ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']" :key="colLabel">
         {{ colLabel }}
@@ -46,4 +57,23 @@ const sendMove = () => {
     <input v-model="endMove" placeholder="End Move (e.g., e6)">
     <button @click="sendMove">Send Move</button>
   </div>
+
+  <!-- Captured Black Pieces -->
+  <div class="captured-pieces">
+      <h2>Captured Black Pieces</h2>
+      <ul>
+        <li v-for="(piece, index) in capturedBlack" :key="index">
+          {{ piece }}
+        </li>
+      </ul>
+  </div>
+  <!-- Captured White Pieces -->
+    <div class="captured-pieces">
+      <h2>Captured White Pieces</h2>
+      <ul>
+        <li v-for="(piece, index) in capturedWhite" :key="index">
+          {{ piece }}
+        </li>
+      </ul>
+    </div>
 </template>


### PR DESCRIPTION
Added rules for pawns: can go forward 1 space, can capture anything (even friendly) 1 diagnal forward, and can move 2 spaces from starting toward opponent. 

Also implements basic capturing rules for pawns and makes a structure for handling and keeping captures and sending the game state as a json object to the websocket